### PR TITLE
remove @types/node to fix multiple error TS2688: Cannot find type definition file

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@bugsounet/node-lpcm16": "^1.0.2",
     "@mapbox/node-pre-gyp": "^1.0.5",
-    "@types/node": "^16.10.2",
     "child_process": "^1.0.2",
     "nan": "^2.15.0",
     "path": "^0.12.7",


### PR DESCRIPTION
I occur this error after trying to npm i for the EXT-Detector, the screenshot as following:

![image](https://user-images.githubusercontent.com/42210002/200143274-010c334f-e67c-4400-a004-dae8b6b37ae5.png)

This error can be fix by removing @types/node from your dependencies